### PR TITLE
Bump prettier from 1.19.1 to 2.0.1

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,4 @@
 module.exports = {
-    arrowParens: 'always',
     quoteProps: 'consistent',
     singleQuote: true,
     trailingComma: 'all',

--- a/package-lock.json
+++ b/package-lock.json
@@ -6492,9 +6492,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-piXGBcY1zoFOG0MvHpNE5reAGseLmaCRifQ/fmfF49BcYkInEs/naD/unxGNAeOKFA5+JxVrPyMvMlpzcd20UA==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.19.0",
     "parcel-bundler": "^1.12.4",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.1",
     "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
Remove arrowParens from the configuration as the default is now 'always'
so it no longer needs to be overridden.